### PR TITLE
[Feat][TC-92] Persistir dados do filtro de extrato no session storage e adicionar botão de limpar esses dados

### DIFF
--- a/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
@@ -131,7 +131,7 @@ export default function FilterExtract({ toggleDrawer }: FilterExtractProps) {
           <BytebankButton
             label="Limpar"
             color="secondary"
-            variant="contained"
+            variant="outlined"
             type="submit"
             style={{ marginTop: 16 }}
             onClick={handleClear}

--- a/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
@@ -1,17 +1,22 @@
-import { BytebankInputController, BytebankButton, BytebankDatePickerController, BytebankSelectController } from "@repo/ui";
-import { FormProvider, useForm } from 'react-hook-form';
-import { ExtractFilter, useFinancialData, useUser } from '@repo/data-access';
+import {
+  BytebankInputController,
+  BytebankButton,
+  BytebankDatePickerController,
+  BytebankSelectController,
+} from "@repo/ui";
+import { FormProvider, useForm } from "react-hook-form";
+import { ExtractFilter, useFinancialData, useUser } from "@repo/data-access";
 
 export interface IForm {
-    categoryId?: string
-    minValue?: number
-    maxValue?: number
-    startDate?: Date | null
-    endDate?: Date | null
+  categoryId?: string;
+  minValue?: number;
+  maxValue?: number;
+  startDate?: Date | null;
+  endDate?: Date | null;
 }
 
 export interface FilterExtractProps {
-   toggleDrawer: (newOpen: boolean) => () => void
+  toggleDrawer: (newOpen: boolean) => () => void;
 }
 
 export default function FilterExtract({
@@ -19,16 +24,35 @@ export default function FilterExtract({
 }: FilterExtractProps) {
   const { user } = useUser();
   const { categories, fetchTransactions } = useFinancialData();
-  const methods = useForm<IForm>({
-    defaultValues: {
-      categoryId: '',
-      minValue: undefined,
-      maxValue: undefined,
-      startDate: null,
-      endDate: null
+
+  const savedFilter = typeof window !== 'undefined' ? sessionStorage.getItem('filterParams') : null;
+  let defaultValues: IForm = {
+    categoryId: '',
+    minValue: undefined,
+    maxValue: undefined,
+    startDate: null,
+    endDate: null
+  };
+
+  if (savedFilter) {
+    try {
+      const parsed = JSON.parse(savedFilter);
+      defaultValues = {
+        categoryId: parsed.categoryId || '',
+        minValue: parsed.minValue,
+        maxValue: parsed.maxValue,
+        startDate: parsed.startDate ? new Date(parsed.startDate) : null,
+        endDate: parsed.endDate ? new Date(parsed.endDate) : null
+      };
+    } catch (error) {
+      console.error('Erro ao parsear filtro salvo', error);
     }
+  }
+
+  const methods = useForm<IForm>({
+    defaultValues
   });
-  
+
   const handleSubmit = (data: IForm) => {
     const filterParams: ExtractFilter = {
       categoryId: data.categoryId,
@@ -37,56 +61,58 @@ export default function FilterExtract({
       startDate: data.startDate ? data.startDate.toISOString() : undefined,
       endDate: data.endDate ? data.endDate.toISOString() : undefined,
     };
+
+    sessionStorage.setItem('filterParams', JSON.stringify(filterParams));
+
     if(user){
       fetchTransactions(user, filterParams);
-      toggleDrawer(false)()
+      toggleDrawer(false)();
     }
   };
-  
+
   return (
-    
-      <FormProvider {...methods}>
-        <form onSubmit={ methods.handleSubmit(handleSubmit) }>
-          {categories && categories.length > 0 && (
-            <BytebankSelectController
-              color='primary'
-              name="categoryId"
-              label="Tipo"
-              options={categories.map(category => ({
-                value: category._id,
-                label: category.name
-            }))}
-            />
-          )}
+    <FormProvider {...methods}>
+      <form onSubmit={ methods.handleSubmit(handleSubmit) }>
+        {categories && categories.length > 0 && (
+          <BytebankSelectController
+            color='primary'
+            name="categoryId"
+            label="Tipo"
+            options={categories.map(category => ({
+              value: category._id,
+              label: category.name
+          }))}
+          />
+        )}
 
-          <BytebankInputController
-            name="minValue"
-            label="Valor Minimo"
-            type="text"
-          />
+        <BytebankInputController
+          name="minValue"
+          label="Valor Minimo"
+          type="text"
+        />
 
-          <BytebankInputController
-            name="maxValue"
-            label="Valor Máximo"
-            type="text"
-          />
-          
-          <BytebankDatePickerController
-            name="startDate"
-            label="Data inicial"
-          />
-          <BytebankDatePickerController
-            name="endDate"
-            label="Data final"
-          />
-          <BytebankButton
-            label="Confirmar"
-            color="secondary"
-            variant="contained"
-            type="submit"
-            style={{ marginTop: 16 }}
-          />
-        </form>
-      </FormProvider>
+        <BytebankInputController
+          name="maxValue"
+          label="Valor Máximo"
+          type="text"
+        />
+        
+        <BytebankDatePickerController
+          name="startDate"
+          label="Data inicial"
+        />
+        <BytebankDatePickerController
+          name="endDate"
+          label="Data final"
+        />
+        <BytebankButton
+          label="Confirmar"
+          color="secondary"
+          variant="contained"
+          type="submit"
+          style={{ marginTop: 16 }}
+        />
+      </form>
+    </FormProvider>
   );
 }

--- a/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
@@ -119,14 +119,14 @@ export default function FilterExtract({ toggleDrawer }: FilterExtractProps) {
         <BytebankDatePickerController name="endDate" label="Data final" />
         <Box
           display="flex"
-          justifyContent="space-between"
+          justifyContent="flex-end"
         >
           <BytebankButton
             label="Confirmar"
             color="secondary"
             variant="contained"
             type="submit"
-            style={{ marginTop: 16 }}
+            style={{ marginTop: 16, marginRight: 16 }}
           />
           <BytebankButton
             label="Limpar"

--- a/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/components/filter/index.tsx
@@ -89,12 +89,14 @@ export default function FilterExtract({
           name="minValue"
           label="Valor Minimo"
           type="text"
+          mask="currency"
         />
 
         <BytebankInputController
           name="maxValue"
           label="Valor Máximo"
           type="text"
+          mask="currency"
         />
         
         <BytebankDatePickerController

--- a/apps/mfe-transactions/src/components/extract/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/index.tsx
@@ -247,21 +247,24 @@ export function BytebankExtract() {
                         gap={"10px"}
                         alignItems="center"
                       >
-                        <IconButton
+                        <Box
+                          display="flex"
                           color="primary"
-                          style={{ border: "1px solid #e0e0e0" }}
+                          alignItems="center"
+                          style={{ border: "1px solid", borderRadius: "50px", padding: "10px"}}
                         >
                           {itens.type !== "income" ? (
-                            <ArrowUpwardIcon style={{ fontSize: "35px" }} />
+                            <ArrowUpwardIcon style={{ fontSize: "35px"}} />
                           ) : (
                             <ArrowUpwardIcon
+                              color="secondary"  
                               style={{
                                 fontSize: "35px",
                                 transform: "rotate(180deg)",
                               }}
                             />
                           )}
-                        </IconButton>
+                        </Box>
                         <Box>
                           <Box
                             width="100%"

--- a/apps/mfe-transactions/src/components/extract/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/index.tsx
@@ -23,6 +23,7 @@ import MenuItem from "@mui/material/MenuItem";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import EditExtract from "./components/edit";
 import { set } from "react-hook-form";
+import { useTheme } from '@repo/utils';
 
 export function BytebankExtract() {
   const { user } = useUser();
@@ -39,6 +40,11 @@ export function BytebankExtract() {
     [key: string]: HTMLElement | null;
   }>({});
   const open = Boolean(anchorEls);
+
+    const { isDarkMode, colors } = useTheme();
+    const bgColor = isDarkMode ? colors['lime.100'] : colors['lime.100']
+    const iconColor = isDarkMode ? colors['lime.900'] : colors['lime.900']
+    const filterBg = isDarkMode ? colors['lime.100'] : colors['lime.100']
 
   useEffect(() => {
     const getTransactions = () => {
@@ -178,7 +184,12 @@ export function BytebankExtract() {
               color="primary"
               onClick={() => setOpenFilter(true)}
               size="small"
-              style={{ border: "1px solid #e0e0e0", borderRadius: "20px", padding:"7px" }}
+              style={{
+                border: "1px solid #e0e0e0",
+                borderRadius: "20px",
+                padding: "7px",
+                backgroundColor: filterBg,
+              }}
             >
               <FilterAltIcon fontSize="small" />
               <Typography fontSize={12}> Filtros</Typography>
@@ -251,10 +262,10 @@ export function BytebankExtract() {
                           {itens.type !== "income" ? (
                             <Box
                               display="flex"
-                              color="primary"
+                              color={iconColor}
                               alignItems="center"
-                              style={{
-                                border: "1px solid #eeeeee",
+                              sx={{
+                                backgroundColor: bgColor,
                                 borderRadius: "50px",
                                 padding: "10px",
                               }}
@@ -265,18 +276,18 @@ export function BytebankExtract() {
                             <Box
                               display="flex"
                               color="primary"
-                              alignItems="center"
-                              style={{
-                                border: "1px solid #D5EA49",
+                              sx={{
+                                backgroundColor: bgColor,
                                 borderRadius: "50px",
                                 padding: "10px",
                               }}
+                              alignItems="center"
                             >
                               <ArrowUpwardIcon
-                                color="secondary"
                                 style={{
                                   fontSize: "35px",
                                   transform: "rotate(180deg)",
+                                  color: iconColor
                                 }}
                               />
                             </Box>

--- a/apps/mfe-transactions/src/components/extract/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/index.tsx
@@ -178,7 +178,7 @@ export function BytebankExtract() {
               color="primary"
               onClick={() => setOpenFilter(true)}
               size="small"
-              style={{ border: "1px solid #e0e0e0", borderRadius: "4px" }}
+              style={{ border: "1px solid #e0e0e0", borderRadius: "20px", padding:"7px" }}
             >
               <FilterAltIcon fontSize="small" />
               <Typography fontSize={12}> Filtros</Typography>

--- a/apps/mfe-transactions/src/components/extract/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/index.tsx
@@ -247,7 +247,7 @@ export function BytebankExtract() {
                         gap={"10px"}
                         alignItems="center"
                       >
-                        <Box>
+                        <Box mr={1}>
                           {itens.type !== "income" ? (
                             <Box
                               display="flex"

--- a/apps/mfe-transactions/src/components/extract/index.tsx
+++ b/apps/mfe-transactions/src/components/extract/index.tsx
@@ -247,22 +247,39 @@ export function BytebankExtract() {
                         gap={"10px"}
                         alignItems="center"
                       >
-                        <Box
-                          display="flex"
-                          color="primary"
-                          alignItems="center"
-                          style={{ border: "1px solid", borderRadius: "50px", padding: "10px"}}
-                        >
+                        <Box>
                           {itens.type !== "income" ? (
-                            <ArrowUpwardIcon style={{ fontSize: "35px"}} />
-                          ) : (
-                            <ArrowUpwardIcon
-                              color="secondary"  
+                            <Box
+                              display="flex"
+                              color="primary"
+                              alignItems="center"
                               style={{
-                                fontSize: "35px",
-                                transform: "rotate(180deg)",
+                                border: "1px solid #eeeeee",
+                                borderRadius: "50px",
+                                padding: "10px",
                               }}
-                            />
+                            >
+                              <ArrowUpwardIcon style={{ fontSize: "35px" }} />
+                            </Box>
+                          ) : (
+                            <Box
+                              display="flex"
+                              color="primary"
+                              alignItems="center"
+                              style={{
+                                border: "1px solid #D5EA49",
+                                borderRadius: "50px",
+                                padding: "10px",
+                              }}
+                            >
+                              <ArrowUpwardIcon
+                                color="secondary"
+                                style={{
+                                  fontSize: "35px",
+                                  transform: "rotate(180deg)",
+                                }}
+                              />
+                            </Box>
                           )}
                         </Box>
                         <Box>

--- a/packages/data-access/src/classes/models/extract.ts
+++ b/packages/data-access/src/classes/models/extract.ts
@@ -21,7 +21,7 @@ export interface ExtractFilter {
     page?: number
     limit?: number
     categoryId?: string
-    minValue?: number
+    minValue?: number | string
     maxValue?: number
     startDate?: string
     endDate?: string

--- a/packages/data-access/src/classes/models/extract.ts
+++ b/packages/data-access/src/classes/models/extract.ts
@@ -22,7 +22,7 @@ export interface ExtractFilter {
     limit?: number
     categoryId?: string
     minValue?: number | string
-    maxValue?: number
+    maxValue?: number | string
     startDate?: string
     endDate?: string
 }


### PR DESCRIPTION
## 🧠 Contexto e objetivo da mudança

Correção de bugs da parte de extrato e filtro.

Essa PR resolve 2 bugs:
-  Resolves #92 
-  Resolves #96 

## 📸 Imagem ou evidência visual (quando aplicável)

<img width="919" height="671" alt="image" src="https://github.com/user-attachments/assets/9d04aadf-3924-4246-adac-840a744db482" />
<img width="408" height="597" alt="image" src="https://github.com/user-attachments/assets/cf25e56d-488e-4bc9-919c-1a89b7671ed9" />


## 🧪 Passos detalhados para testar

1. Clone o repositório e acesse a branch do PR
2. Rode o projeto com: `npm run dev` no backend
3. Rode o projeto com: `yarn run dev` no frontend
4. Logue com seu usuário
5. Interaja com as funcionalidade da dashboard
- [ ] os ícones de entrada e saída devem estar com as cores do projeto;
- [ ] os ícones não devem ser mais clicáveis pois não são mais botões
- [ ] ao abrir o filtro e fazer uma filtragem e confirmar, ao voltar para os filtros os valores etados anteriormente devem estar salvos.
- [ ] ao clicar em LIMPAR nos filtros ele deve limpar todos os valores ali salvos.


## 🔧 Tipo da alteração

fix: Correção de algum bug  

- [x] fix
- [x ] feat

## ✅ Checklist

- [x] O código segue os padrões definidos no projeto
- [x] Foi testado manualmente
- [x] Este PR está relacionado a alguma issue (adicione abaixo, se aplicável)


## 🧩 Issues relacionadas

-  Resolves #92 
-  Resolves #96 
