### PR TITLE
[fix] Adiciona removeItem do session storage ao fazer logout

### DIFF
--- a/packages/data-access/src/contexts/user.context.tsx
+++ b/packages/data-access/src/contexts/user.context.tsx
@@ -32,6 +32,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } else {
       setUser(null);
       setToken(null);
+      sessionStorage.removeItem("filterParams");
     }
     setLoading(false);
   }, [sessionUser, sessionToken, loading]);


### PR DESCRIPTION
## 🧠 Contexto e objetivo da mudança

Adicionar a remoção do parâmetro do filtro do session storage ao deslogar da plataforma.

## 📸 Imagem ou evidência visual 
![filter](https://github.com/user-attachments/assets/b2a4cea4-09b9-4fb2-b30e-30d6228d9115)


## 🧪 Passos detalhados para testar

1. Clone o repositório e acesse a branch do PR
2. Rode o projeto com: `npm run dev` no backend
3. Rode o projeto com: `yarn run dev` no frontend
4. Logue com seu usuário
5. Interaja com as funcionalidade de filtro:
- [ ] ao o filtro e setar qualquer parâmetro de filtragem , salvar e depois deslogar no sessionStorage (application -> session storage) não deve manter os parâmetros dessa filtragem nomeada "filterParams"


## 🔧 Tipo da alteração

fix: Correção de algum bug  


- [x] fix

## ✅ Checklist

- [x] O código segue os padrões definidos no projeto
- [x] Foi testado manualmente
- [x] Foram criados/atualizados testes automatizados (quando aplicável)
- [x] A documentação (README, comentários, etc) foi atualizada
- [x] Este PR está relacionado a alguma issue (adicione abaixo, se aplicável)

